### PR TITLE
Fortran changes for proper leading dimension on x,y,z

### DIFF
--- a/_basic/cuda/source_code/rdf.f90
+++ b/_basic/cuda/source_code/rdf.f90
@@ -2,7 +2,6 @@
 module readdata
       contains
       subroutine readdcd(maxframes,maxatoms,x,y,z,xbox,ybox,zbox,natoms,nframes)
-      use cudafor
       implicit none
       integer i,j
       integer maxframes,maxatoms
@@ -22,16 +21,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-        read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+        read(10) (d(i),i=1, 6)
               
-        read(10) (x(i,j),j=1,natoms)
-        read(10) (y(i,j),j=1,natoms)
-        read(10) (z(i,j),j=1,natoms)
+        read(10) (x(i,j),i=1,natoms)
+        read(10) (y(i,j),i=1,natoms)
+        read(10) (z(i,j),i=1,natoms)
       end do
       xbox=d(1)
       ybox=d(3)
@@ -42,12 +41,11 @@ module readdata
       end subroutine readdcd
 ! Todo: Add global attribute 
       attributes() subroutine pair_calculation( x,y,z,g,natoms,nframes,xbox,ybox,zbox,del,cut)
-          use cudafor
           implicit none
-          real*4     :: x(:,:)
-          real*4     :: y(:,:)
-          real*4    :: z(:,:)
-          double precision,intent(inout)    :: g(:)
+          real*4    :: x(natoms,*)
+          real*4    :: y(natoms,*)
+          real*4    :: z(natoms,*)
+          double precision,intent(inout)    :: g(*)
           integer, value :: nframes,natoms,ind
           double precision, value :: xbox,ybox,zbox,del,cut
           integer i,j,iconf
@@ -59,17 +57,17 @@ module readdata
           do iconf=1,nframes
            if(i<=natoms .and. j<=natoms) then
 
-             dx=x(iconf,i)-x(iconf,j)
-             dy=y(iconf,i)-y(iconf,j)
-             dz=z(iconf,i)-z(iconf,j)
+             dx=x(i,iconf)-x(j,iconf)
+             dy=y(i,iconf)-y(j,iconf)
+             dz=z(i,iconf)-z(j,iconf)
 
              dx=dx-nint(dx/xbox)*xbox
              dy=dy-nint(dy/ybox)*ybox
              dz=dz-nint(dz/zbox)*zbox
 
              r=dsqrt(dx**2+dy**2+dz**2)
-             ind=int(r/del)+1
              if(r<cut)then
+               ind=int(r/del)+1
                !Todo: Add atomic Add function call
                g(ind) = g(ind) + 1.0d0
              endif

--- a/_basic/iso/source_code/rdf.f90
+++ b/_basic/iso/source_code/rdf.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -96,18 +96,17 @@ program rdf
          if (mod(iconf,1).eq.0) print*,iconf
          do i=1,natoms
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
-               !if (ind.le.nbin) then
                if(r<cut)then
+                  ind=int(r/del)+1
                   g(ind)=g(ind)+1.0d0
                endif
             enddo

--- a/_basic/openacc/source_code/SOLUTION/rdf_collapse.f90
+++ b/_basic/openacc/source_code/SOLUTION/rdf_collapse.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -97,19 +97,18 @@ program rdf
          if (mod(iconf,1).eq.0) print*,iconf
          !$acc parallel loop collapse(2) default(present)
          do i=1,natoms
-            !$acc loop
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$acc atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openacc/source_code/SOLUTION/rdf_data_directive.f90
+++ b/_basic/openacc/source_code/SOLUTION/rdf_data_directive.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -100,17 +100,17 @@ program rdf
          do i=1,natoms
             !$acc loop
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$acc atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openacc/source_code/SOLUTION/rdf_gang_vector.f90
+++ b/_basic/openacc/source_code/SOLUTION/rdf_gang_vector.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -100,17 +100,17 @@ program rdf
          do i=1,natoms
             !$acc loop vector
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$acc atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openacc/source_code/SOLUTION/rdf_gang_vector_length.f90
+++ b/_basic/openacc/source_code/SOLUTION/rdf_gang_vector_length.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -100,17 +100,17 @@ program rdf
          do i=1,natoms
             !$acc loop vector
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$acc atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openacc/source_code/SOLUTION/rdf_kernel_directive.f90
+++ b/_basic/openacc/source_code/SOLUTION/rdf_kernel_directive.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -99,17 +99,17 @@ program rdf
          do i=1,natoms
             !$acc loop independent
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$acc atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openacc/source_code/SOLUTION/rdf_parallel_directive.f90
+++ b/_basic/openacc/source_code/SOLUTION/rdf_parallel_directive.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -98,17 +98,17 @@ program rdf
          do i=1,natoms
             !$acc loop
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$acc atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openacc/source_code/rdf.f90
+++ b/_basic/openacc/source_code/rdf.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -96,18 +96,17 @@ program rdf
          if (mod(iconf,1).eq.0) print*,iconf
          do i=1,natoms
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
-               !if (ind.le.nbin) then
                if(r<cut)then
+                  ind=int(r/del)+1
                   g(ind)=g(ind)+1.0d0
                endif
             enddo

--- a/_basic/openmp/source_code/SOLUTION/rdf_offload.f90
+++ b/_basic/openmp/source_code/SOLUTION/rdf_offload.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -98,18 +98,17 @@ program rdf
          !$omp target teams distribute parallel do private(dx,dy,dz,r,ind)
          do i=1,natoms
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
-               !if (ind.le.nbin) then
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$omp atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openmp/source_code/SOLUTION/rdf_offload_collapse.f90
+++ b/_basic/openmp/source_code/SOLUTION/rdf_offload_collapse.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -98,18 +98,17 @@ program rdf
          !$omp target teams distribute parallel do private(dx,dy,dz,r,ind) collapse(2)
          do i=1,natoms
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
-               !if (ind.le.nbin) then
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$omp atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openmp/source_code/SOLUTION/rdf_offload_loop.f90
+++ b/_basic/openmp/source_code/SOLUTION/rdf_offload_loop.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -99,18 +99,17 @@ program rdf
          do i=1,natoms
          !$omp loop
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
-               !if (ind.le.nbin) then
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$omp atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openmp/source_code/SOLUTION/rdf_offload_split.f90
+++ b/_basic/openmp/source_code/SOLUTION/rdf_offload_split.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -99,18 +99,17 @@ program rdf
          do i=1,natoms
             !$omp parallel do private(dx,dy,dz,r,ind)
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
-               !if (ind.le.nbin) then
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$omp atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openmp/source_code/SOLUTION/rdf_offload_split_num.f90
+++ b/_basic/openmp/source_code/SOLUTION/rdf_offload_split_num.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -99,18 +99,17 @@ program rdf
          do i=1,natoms
             !$omp parallel do private(dx,dy,dz,r,ind)
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
-               !if (ind.le.nbin) then
                if(r<cut)then
+                  ind=int(r/del)+1
                   !$omp atomic
                   g(ind)=g(ind)+1.0d0
                endif

--- a/_basic/openmp/source_code/rdf.f90
+++ b/_basic/openmp/source_code/rdf.f90
@@ -25,16 +25,16 @@ module readdata
       read(10) natoms
       print*,"Total number of frames and atoms are",tframes,natoms
 
-      allocate ( x(maxframes,natoms) )
-      allocate ( y(maxframes,natoms) )
-      allocate ( z(maxframes,natoms) )
+      allocate ( x(natoms,maxframes) )
+      allocate ( y(natoms,maxframes) )
+      allocate ( z(natoms,maxframes) )
 
-      do i = 1,nframes
-           read(10) (d(j),j=1, 6)
+      do j = 1,nframes
+           read(10) (d(i),i=1, 6)
               
-           read(10) (x(i,j),j=1,natoms)
-           read(10) (y(i,j),j=1,natoms)
-           read(10) (z(i,j),j=1,natoms)
+           read(10) (x(i,j),i=1,natoms)
+           read(10) (y(i,j),i=1,natoms)
+           read(10) (z(i,j),i=1,natoms)
       end do
       
       xbox=d(1)
@@ -96,18 +96,17 @@ program rdf
          if (mod(iconf,1).eq.0) print*,iconf
          do i=1,natoms
             do j=1,natoms
-               dx=x(iconf,i)-x(iconf,j)
-               dy=y(iconf,i)-y(iconf,j)
-               dz=z(iconf,i)-z(iconf,j)
+               dx=x(i,iconf)-x(j,iconf)
+               dy=y(i,iconf)-y(j,iconf)
+               dz=z(i,iconf)-z(j,iconf)
 
                dx=dx-nint(dx/xbox)*xbox
                dy=dy-nint(dy/ybox)*ybox
                dz=dz-nint(dz/zbox)*zbox
    
                r=dsqrt(dx**2+dy**2+dz**2)
-               ind=int(r/del)+1
-               !if (ind.le.nbin) then
                if(r<cut)then
+                  ind=int(r/del)+1
                   g(ind)=g(ind)+1.0d0
                endif
             enddo


### PR DESCRIPTION
In Fortran, the 1st dimension (left-most) is the leading dimension.  Make the x, y, an z arrays, which are accessed mainly in the inner loop with i and j, index through dimension 1.  Other minor things, move the index calculation which contains a divide inside of the cutoff condition.  And, when calling a CUDA Fortran global subroutine, change the dummy arguments from assumed shape (which has colons for dimensions) to assumed size.  These perform much better, when the size is not needed, or is passed in as an argument anyway.