### PR TITLE
Update typo in example

### DIFF
--- a/_basic/cuda/jupyter_notebook/nways_cuda.ipynb
+++ b/_basic/cuda/jupyter_notebook/nways_cuda.ipynb
@@ -459,7 +459,7 @@
     "threads. Now let us look at creating multiple blocks, each block containing multiple threads.\n",
     "\n",
     "To understand it lets take a scenario where the total number of vector elements is 32 which needs to be added in parallel. Total number of parallel execution unit required is 32. As a first step let us define that each block contains eight threads(we are not saying this is optimal configuration and is just for explanation purpose). Next we define the number of blocks. The simplest calculation is No_Of_Blocks = 32/8 where 8 is number of threads per blocks. The code changes required to launch 4 blocks with 8 thread each is as shown below: \n",
-    "1. Change _<<<1,1>>>_ to <<<4,8>>>_ which basically launches 4  threads per block and 8 total blocks\n",
+    "1. Change _<<<1,1>>>_ to <<<4,8>>>_ which basically launches 8  threads per block and 4 total blocks\n",
     "2. Access the array with both thread index and block index using private variable passed by default to call CUDA kernel: _threadIdx.x_ and _blockIdx.x_ and _bloxkDim.x_ which tells how many threads are allocated per block. \n",
     "\n",
     "    \n",


### PR DESCRIPTION
There was typo in order of threads and blocks in one example